### PR TITLE
Bugfix for media query width calculation

### DIFF
--- a/defaults.less
+++ b/defaults.less
@@ -208,5 +208,5 @@
 @half-spacing-unit: @base-spacing-unit / 2;
 @line-height-ratio: @base-line-height/@base-font-size;
 
-@palm-end:@lap-start*1-1;
-@lap-end:@desk-start*1-1;
+@palm-end: (@lap-start*1-1);
+@lap-end: (@desk-start*1-1);


### PR DESCRIPTION
LESS 1.4 needs strictMath.

(1 + 1)  // 2
1 + 1    // 1+1
