### PR TITLE
Fix @line-height-ratio calculation bug caused by LESS 1.4 strictMath

### DIFF
--- a/defaults.less
+++ b/defaults.less
@@ -205,8 +205,8 @@
  * Assign our `$base-line-height` to a new spacing var for more transparency.
  */
 @base-spacing-unit: @base-line-height;
-@half-spacing-unit: @base-spacing-unit / 2;
-@line-height-ratio: @base-line-height/@base-font-size;
+@half-spacing-unit: (@base-spacing-unit / 2);
+@line-height-ratio: (@base-line-height/@base-font-size);
 
 @palm-end: (@lap-start*1-1);
 @lap-end: (@desk-start*1-1);


### PR DESCRIPTION
This is a fix for another issue that has cropped up due to the strictMath mode
introduced in LESS 1.4.

The @line-height-ratio variable evaluates to 24/16 instead of 1.5. This commit
adds parentheses around the division operation to fix the issue.
