### PR TITLE
LESS 1.5.0 @line-height-ratio fix

### DIFF
--- a/defaults.less
+++ b/defaults.less
@@ -206,7 +206,7 @@
  */
 @base-spacing-unit: @base-line-height;
 @half-spacing-unit: (@base-spacing-unit / 2);
-@line-height-ratio: (@base-line-height/@base-font-size);
+@line-height-ratio: unit((@base-line-height/@base-font-size));
 
 @palm-end: (@lap-start*1-1);
 @lap-end: (@desk-start*1-1);


### PR DESCRIPTION
In LESS 1.5.0, @line-height-ratio is incorrectly evaluated with a 'px'
unit added to the end. This causes unexpected results mainly with its
use in base/main.less for the font property of the html selector, where
line height is determined to be 1.6px rather than 1.6 as a ratio.

Wrapping the equation in LESS's 'unit' function, without the optional
second unit parameter ensures the output is a unitless integer
